### PR TITLE
Custom Metrics

### DIFF
--- a/lib/alephant/renderer/view_mapper.rb
+++ b/lib/alephant/renderer/view_mapper.rb
@@ -32,8 +32,8 @@ module Alephant
       private
 
       def raise_error(path)
-        raise "Invalid path: '#{path}'"
         logger.metric({:name => "RenderViewMapperInvalidPath", :unit => "Count", :value => 1})
+        raise "Invalid path: '#{path}'"
       end
 
       def model(view_id, data)


### PR DESCRIPTION
![getinsertpic.com](http://media4.giphy.com/media/JbBGymTFL7AgU/200.gif)
## Problem

We want to plug some custom metrics about the broker into AWS CloudWatch.
## Solution

Use the new [Alephant-Logger](https://github.com/BBC-News/alephant-logger) `metric` interface.

> Note: Alephant-Logger has been implemented in a way that means if the consumer of Alephant-Renderer doesn't have a need for recording CloudWatch metrics then they simply don't wrap the Logger in the provided Decorator class (meaning any calls to `metric` become a no-op)
