### PR TITLE
[READY] Peg mustache version

### DIFF
--- a/alephant-renderer.gemspec
+++ b/alephant-renderer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-rspec"
 
   spec.add_runtime_dependency 'i18n'
-  spec.add_runtime_dependency 'mustache', '>= 0.99.5'
+  spec.add_runtime_dependency 'mustache', '~> 0'
   spec.add_runtime_dependency 'alephant-logger'
   spec.add_runtime_dependency 'hashie'
 end

--- a/alephant-renderer.gemspec
+++ b/alephant-renderer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-rspec"
 
   spec.add_runtime_dependency 'i18n'
-  spec.add_runtime_dependency 'mustache', '~> 0'
+  spec.add_runtime_dependency 'mustache', '~> 0.99.5'
   spec.add_runtime_dependency 'alephant-logger'
   spec.add_runtime_dependency 'hashie'
 end


### PR DESCRIPTION
### Problem

Now that mustache has reached a `1.0` major version they've specified that it needs to be run with at least ruby version `2.0`. This is a problem with jruby as the with the `1.7x` current release the underlying version reported is `1.9.3p392`.

You can run jruby with one of the following to run it in `2.0` mode:
- `jruby --2.0`
- `export JRUBY_OPTS=--2.0`
- `echo "compat.version=2.0" > ~/.jrubyrc`

but this isn't fully supported and for production apps isn't really an option.
### Solution

Peg the version so that all releases up to the major `1` release can be used.
