### PR TITLE
Fix renderer gsubbing

### DIFF
--- a/lib/alephant/renderer/views.rb
+++ b/lib/alephant/renderer/views.rb
@@ -8,13 +8,13 @@ module Alephant
       end
 
       def self.get_registered_class(id)
-        @@views[id]
+        @@views[id.downcase]
       end
 
       def self.underscorify(str)
         str.gsub(/::/, "/").
-          gsub(/([A-Z]+)([A-Z][a-z])/,"\1_\2").
-          gsub(/([a-z\d])([A-Z])/,"\1_\2").
+          gsub(/([A-Z]+)([A-Z][a-z])/,"\\1_\\2").
+          gsub(/([a-z\d])([A-Z])/,"\\1_\\2").
           tr("-", "_").
           downcase
       end

--- a/spec/fixtures/components/foo-renderer/models/BAR_ABC.rb
+++ b/spec/fixtures/components/foo-renderer/models/BAR_ABC.rb
@@ -1,5 +1,5 @@
 module MyApp
-  class Foo < Alephant::Renderer::Views::Html
+  class BarAbc < Alephant::Renderer::Views::Html
     def content
       @data[:content]
     end

--- a/spec/fixtures/components/foo-renderer/models/foo_xyz.rb
+++ b/spec/fixtures/components/foo-renderer/models/foo_xyz.rb
@@ -1,5 +1,5 @@
 module MyApp
-  class Bar < Alephant::Renderer::Views::Html
+  class FooXyz < Alephant::Renderer::Views::Html
     def content
       @data[:content]
     end

--- a/spec/renderer_spec.rb
+++ b/spec/renderer_spec.rb
@@ -43,11 +43,11 @@ describe Alephant::Renderer do
 
       context "using `bar`, `foo`, `json` models" do
         it "contains a View for `bar` model" do
-          expect(subject.views.key? "bar").to be
+          expect(subject.views.key? "BAR_ABC").to be
         end
 
         it "contains a View for `foo` model" do
-          expect(subject.views.key? "foo").to be
+          expect(subject.views.key? "foo_xyz").to be
         end
 
         it "contains a View for `json` model" do


### PR DESCRIPTION
Fix the renderer view name conversion when using double quotes.

```
Problem:
"editoria\u0001_\u0002ext"
"counci\u0001_\u0002ditoria\u0001_\u0002ext"

Fixed:
"editorial_text"
"council_editorial_text"
"council_result_table"
```

Also updated the tests, to catch this.

https://jira.dev.bbc.co.uk/browse/CONNPOL-2870

![](https://media.giphy.com/media/HJkGbf8dVnyUM/giphy.gif)