### PR TITLE
Move translations and the renderer engine out of the renderer models

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ There are two template paths in Alephant, the template path and the partials pat
 
 ```ruby
 def renderer_engine
-  partial_path = File.join(base_path + '/templates/')
+  partial_path = File.join(base_path, 'templates/')
   Alephant::Renderer::Engine::Mustache.new(base_path, template_name, partial_path)
 end
 ```

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ For each translation, a seperate model and view is needed.
 
 #### Model
 
-All that's needed in the model is to override the LOCALE constant:
+A model should override the `locale` method:
 
 ```ruby
-class TestModel < Alephant::Views::Base
-  LOCALE = :cy
+class TestModel < Alephant::Views::HTML
+  def locale
+      :cy
+  end
 end
 ```
 
@@ -178,20 +180,76 @@ en:
     key: 'A translation!'
 ```
 
-##### Default
+##### Other options
 
-By default, if the translation key doesn't exist then the translation key is used as the translation.
+The `t()` method takes a second hash argument for accessing other I18n features. Below are a few of the more common uses of this argument.
 
-You can override this behaviour and provide a default:
+By default, if the translation key doesn't exist then the translation key is used as the translation. You can override this behaviour and provide an explicit default:
 
 ```ruby
 def my_translation
-  t 'missing_key', :default => 'Some default'
+  t 'missing_key', default: 'Some default'
 end
-
 ```
 
-So if the key doesn't exists, then 'Some default' is the translation.
+Plurality can also be handled, including support for languages with multiple pluralities. You would define your translation in the yaml file like this:
+
+```yaml
+en:
+    test_template:
+        pluralized_key:
+            one: 'Singular string'
+            other: 'Plural string'
+```
+and the code would look like:
+```ruby
+t 'pluralized_key', count: @num_of_things
+```
+
+You can force it to use a different locale if you need:
+```ruby
+t 'some_key', locale: :cy
+```
+
+You can use strings from another subsection of the translations. E.g. if your renderer was currently _myRenderer_ and your translations yaml looked like this:
+```yaml
+en:
+    myRenderer:
+        'some_key': 'some string'
+    general:
+        'another_key': 'another string'
+```
+You can do this in code:
+```ruby
+t 'another_key', scope: 'general'
+```
+
+You can do simple variable substitution, as often dynamic data can be in a different position in different strings. Your yaml might look like:
+```yaml
+en:
+    myRenderer:
+        'some_key': 'some %{insert} string'
+```
+and the code looks like:
+```ruby
+t 'some_key', insert: 'text inserted into a'
+```
+
+## Templates
+
+The template engine is built into the Alephant::Views::HTML class. Create methods that correspond to variables, and they will become available to the template.
+
+### Paths
+
+There are two template paths in Alephant, the template path and the partials path. By default in HTML renderers, the template path is `../templates/` from your model, and the partials path is `../../lib/templates` from your model. You can change either of these pathing strategies by overridding the default renderer_engine instantiation.
+
+```ruby
+def renderer_engine
+  partial_path = File.join(base_path + '/templates/')
+  Alephant::Renderer::Engine::Mustache.new(base_path, template_name, partial_path)
+end
+```
+In the above example, base_path is the parent of the current model folder, so this will make the partials path equal to the template path.
 
 
 ## Contributing

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -1,0 +1,30 @@
+require "mustache"
+
+module Alephant
+  module Renderer
+    module Engine
+      class Mustache
+        def initialize(namespace)
+          @mustache = ::Mustache.new
+          @namespace = namespace
+        end
+
+        def template
+          @template_string ||= File.open(template_file).read
+        end
+
+        def template_file
+          File.join(
+            base_path,
+            "templates",
+            "#{namespace}.#{template_extension}"
+          )
+        end
+
+        def render(data)
+          @mustache.render(template, data)
+        end
+      end
+    end
+  end
+end

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -12,8 +12,8 @@ module Alephant
           @mustache.class.template_path = partials_path || default_shared_template_path
         end
 
-        def template
-          @template_string ||= File.open(template_file).read
+        def render(data)
+          @mustache.render(template, data)
         end
 
         def default_shared_template_path
@@ -24,12 +24,14 @@ module Alephant
           File.join(@base_path, 'templates')
         end
 
+        private
+
         def template_file
           File.join(template_path, "#{@namespace}.#{::Mustache.template_extension}")
         end
 
-        def render(data)
-          @mustache.render(template, data)
+        def template
+          @template_string ||= File.open(template_file).read
         end
       end
     end

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -7,16 +7,15 @@ module Alephant
         def initialize(base_path, namespace, partials_path = nil)
           @namespace = namespace
           @base_path = base_path
-
-          @mustache = ::Mustache.new
-          @mustache.class.template_path = partials_path || default_shared_template_path
+          @partial_path = partials_path || default_shared_partial_path
         end
 
         def render(data)
-          @mustache.render(template, data)
+          mustache.template_path = @partial_path
+          mustache.render(template, data)
         end
 
-        def default_shared_template_path
+        def default_shared_partial_path
           File.join(@base_path, '/../lib/templates')
         end
 
@@ -32,6 +31,10 @@ module Alephant
 
         def template
           @template_string ||= File.open(template_file).read
+        end
+
+        def mustache
+          ::Mustache
         end
       end
     end

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -1,27 +1,27 @@
-require "mustache"
+require 'mustache'
 
 module Alephant
   module Renderer
     module Engine
       class Mustache
-        def initialize(base_path, namespace)
+        def initialize(base_path, namespace, partials_path = nil)
           @namespace = namespace
           @base_path = base_path
 
           @mustache = ::Mustache.new
-          @mustache.class.template_path = shared_template_path
+          @mustache.class.template_path = partials_path || default_shared_template_path
         end
 
         def template
           @template_string ||= File.open(template_file).read
         end
 
-        def shared_template_path
-          File.join(@base_path, "/../lib/templates")
+        def default_shared_template_path
+          File.join(@base_path, '/../lib/templates')
         end
 
         def template_path
-          File.join(@base_path, "templates")
+          File.join(@base_path, 'templates')
         end
 
         def template_file

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -4,9 +4,10 @@ module Alephant
   module Renderer
     module Engine
       class Mustache
-        def initialize(namespace)
+        def initialize(base_path, namespace)
           @mustache = ::Mustache.new
           @namespace = namespace
+          @base_path = base_path
         end
 
         def template
@@ -15,9 +16,9 @@ module Alephant
 
         def template_file
           File.join(
-            base_path,
+            @base_path,
             "templates",
-            "#{namespace}.#{template_extension}"
+            "#{@namespace}.#{::Mustache.template_extension}"
           )
         end
 

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -5,21 +5,27 @@ module Alephant
     module Engine
       class Mustache
         def initialize(base_path, namespace)
-          @mustache = ::Mustache.new
           @namespace = namespace
           @base_path = base_path
+
+          @mustache = ::Mustache.new
+          @mustache.class.template_path = shared_template_path
         end
 
         def template
           @template_string ||= File.open(template_file).read
         end
 
+        def shared_template_path
+          File.join(@base_path, "/../lib/templates")
+        end
+
+        def template_path
+          File.join(@base_path, "templates")
+        end
+
         def template_file
-          File.join(
-            @base_path,
-            "templates",
-            "#{@namespace}.#{::Mustache.template_extension}"
-          )
+          File.join(template_path, "#{@namespace}.#{::Mustache.template_extension}")
         end
 
         def render(data)

--- a/lib/alephant/renderer/engine/mustache.rb
+++ b/lib/alephant/renderer/engine/mustache.rb
@@ -16,7 +16,7 @@ module Alephant
         end
 
         def default_shared_partial_path
-          File.join(@base_path, '/../lib/templates')
+          File.join(@base_path, '../lib/templates')
         end
 
         def template_path

--- a/lib/alephant/renderer/i18n/locale_component_yaml.rb
+++ b/lib/alephant/renderer/i18n/locale_component_yaml.rb
@@ -4,16 +4,17 @@ module Alephant
   module Renderer
     module I18n
       class LocaleComponentYaml
-        def initialize(base_path, locale)
+        def initialize(base_path, locale, namespace)
           load_translations_from base_path
           @locale = locale
+          @namespace = namespace
         end
 
         def t(key, params = {})
           i18n_lib.locale = @locale
-          prefix = %r{/([^\/]+)\.mustache}.match(template_file)[1]
           params[:default] = key unless params[:default]
-          i18n_lib.translate("#{prefix}.#{key}", params)
+          params[:scope] = @namespace unless params[:scope]
+          i18n_lib.translate(key, params)
         end
 
         private
@@ -34,8 +35,7 @@ module Alephant
 
         def translation_filename(base_path)
           File.join(
-            Pathname.new(base_path).parent,
-            "locale",
+            base_path,
             "*.yml")
         end
 

--- a/lib/alephant/renderer/i18n/locale_component_yaml.rb
+++ b/lib/alephant/renderer/i18n/locale_component_yaml.rb
@@ -1,13 +1,15 @@
-require "i18n"
+require 'i18n'
 
 module Alephant
   module Renderer
     module I18n
       class LocaleComponentYaml
-        def initialize(base_path, locale, namespace)
-          load_translations_from base_path
+        def initialize(locale, namespace, translations_path = nil)
+          @translations_path = translations_path
           @locale = locale
           @namespace = namespace
+
+          load_translations
         end
 
         def t(key, params = {})
@@ -19,28 +21,31 @@ module Alephant
 
         private
 
-        def load_translations_from(base_path)
-          if i18n_lib.load_path.empty?
-            i18n_lib.config.enforce_available_locales = false
-            i18n_lib.load_path = i18n_load_path_from(base_path)
-            i18n_lib.backend.load_translations
-          end
+        def load_translations
+          return unless i18n_lib.available_locales.empty?
+          i18n_lib.backend.load_translations(translations_files)
         end
 
-        def i18n_load_path_from(base_path)
-          Dir[translation_filename(base_path)]
+        def translations_files
+          Dir[translation_filename]
             .flatten
             .uniq
         end
 
-        def translation_filename(base_path)
+        def translation_filename
           File.join(
-            base_path,
-            "*.yml")
+            translations_path,
+            '*.yml')
+        end
+
+        def translations_path
+          @translations_path || './components/lib/locales'
         end
 
         def i18n_lib
-          ::I18n
+          i18n_lib = ::I18n
+          i18n_lib.enforce_available_locales = false
+          i18n_lib
         end
       end
     end

--- a/lib/alephant/renderer/i18n/locale_component_yaml.rb
+++ b/lib/alephant/renderer/i18n/locale_component_yaml.rb
@@ -1,0 +1,48 @@
+require "i18n"
+
+module Alephant
+  module Renderer
+    module I18n
+      class LocaleComponentYaml
+        def initialize(base_path, locale)
+          load_translations_from base_path
+          @locale = locale
+        end
+
+        def t(key, params = {})
+          i18n_lib.locale = @locale
+          prefix = %r{/([^\/]+)\.mustache}.match(template_file)[1]
+          params[:default] = key unless params[:default]
+          i18n_lib.translate("#{prefix}.#{key}", params)
+        end
+
+        private
+
+        def load_translations_from(base_path)
+          if i18n_lib.load_path.empty?
+            i18n_lib.config.enforce_available_locales = false
+            i18n_lib.load_path = i18n_load_path_from(base_path)
+            i18n_lib.backend.load_translations
+          end
+        end
+
+        def i18n_load_path_from(base_path)
+          Dir[translation_filename(base_path)]
+            .flatten
+            .uniq
+        end
+
+        def translation_filename(base_path)
+          File.join(
+            Pathname.new(base_path).parent,
+            "locale",
+            "*.yml")
+        end
+
+        def i18n_lib
+          ::I18n
+        end
+      end
+    end
+  end
+end

--- a/lib/alephant/renderer/version.rb
+++ b/lib/alephant/renderer/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Renderer
-    VERSION = "3.0.0"
+    VERSION = '3.0.0'.freeze
   end
 end

--- a/lib/alephant/renderer/version.rb
+++ b/lib/alephant/renderer/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Renderer
-    VERSION = "2.0.4"
+    VERSION = "3.0.0"
   end
 end

--- a/lib/alephant/renderer/views/base.rb
+++ b/lib/alephant/renderer/views/base.rb
@@ -1,6 +1,6 @@
-require "alephant/renderer/views"
-require "hashie"
-require "pathname"
+require 'alephant/renderer/views'
+require 'hashie'
+require 'pathname'
 
 module Alephant
   module Renderer
@@ -39,7 +39,7 @@ module Alephant
 
           def inherited(subclass)
             current_dir = File.dirname(caller.first[%r{/[^:]+}])
-            dir_path    = Pathname.new(File.join(current_dir, "..")).realdirpath
+            dir_path    = Pathname.new(File.join(current_dir, '..')).realdirpath
 
             subclass.base_path = dir_path.to_s
 

--- a/lib/alephant/renderer/views/base.rb
+++ b/lib/alephant/renderer/views/base.rb
@@ -38,7 +38,7 @@ module Alephant
           attr_accessor :base_path
 
           def inherited(subclass)
-            current_dir = File.dirname(caller.first[/\/[^:]+/])
+            current_dir = File.dirname(caller.first[%r{/[^:]+}])
             dir_path    = Pathname.new(File.join(current_dir, "..")).realdirpath
 
             subclass.base_path = dir_path.to_s

--- a/lib/alephant/renderer/views/html.rb
+++ b/lib/alephant/renderer/views/html.rb
@@ -8,6 +8,10 @@ module Alephant
       class Html
         include ::Alephant::Renderer::Views::Base
 
+        class << self
+          attr_accessor :template_path
+        end
+
         def setup
           @content_type = "text/html"
           @translator = translator
@@ -15,7 +19,7 @@ module Alephant
         end
 
         def render
-          @renderer.render to_h
+          @renderer.render self
         end
 
         private

--- a/lib/alephant/renderer/views/html.rb
+++ b/lib/alephant/renderer/views/html.rb
@@ -28,7 +28,7 @@ module Alephant
         end
 
         def renderer_engine
-          Alephant::Renderer::Engine::Mustache.new(template_name)
+          Alephant::Renderer::Engine::Mustache.new(base_path, template_name)
         end
 
         def t(key, params = {})
@@ -40,7 +40,7 @@ module Alephant
         end
 
         def render
-          @renderer.render Hash(self)
+          @renderer.render to_h
         end
 
         private

--- a/lib/alephant/renderer/views/html.rb
+++ b/lib/alephant/renderer/views/html.rb
@@ -15,7 +15,16 @@ module Alephant
         end
 
         def translator
-          Alephant::Renderer::I18n::LocaleComponentYaml.new(base_path, locale)
+          Alephant::Renderer::I18n::LocaleComponentYaml.new(
+            translations_path,
+            locale,
+            template_name)
+        end
+
+        def translations_path
+          File.join(
+            Pathname.new(base_path).parent,
+            "locale")
         end
 
         def renderer_engine

--- a/lib/alephant/renderer/views/html.rb
+++ b/lib/alephant/renderer/views/html.rb
@@ -1,6 +1,6 @@
-require "alephant/renderer/views/base"
-require "alephant/renderer/engine/mustache"
-require "alephant/renderer/i18n/locale_component_yaml"
+require 'alephant/renderer/views/base'
+require 'alephant/renderer/engine/mustache'
+require 'alephant/renderer/i18n/locale_component_yaml'
 
 module Alephant
   module Renderer
@@ -9,11 +9,12 @@ module Alephant
         include ::Alephant::Renderer::Views::Base
 
         class << self
+          # FIXME: remove this when we've gotten rid of all of the `self.template_path` directives
           attr_accessor :template_path
         end
 
         def setup
-          @content_type = "text/html"
+          @content_type = 'text/html'
           @translator = translator
           @renderer = renderer_engine
         end
@@ -26,15 +27,15 @@ module Alephant
 
         def translator
           Alephant::Renderer::I18n::LocaleComponentYaml.new(
-            translations_path,
             locale,
-            template_name)
+            template_name,
+            translations_path)
         end
 
         def translations_path
           File.join(
             Pathname.new(base_path).parent,
-            "locale")
+            'locale')
         end
 
         def renderer_engine
@@ -50,7 +51,7 @@ module Alephant
         end
 
         def template_name
-          Mustache.underscore(self.class.to_s).split("/").last
+          Mustache.underscore(self.class.to_s).split('/').last
         end
       end
     end

--- a/lib/alephant/renderer/views/html.rb
+++ b/lib/alephant/renderer/views/html.rb
@@ -14,6 +14,12 @@ module Alephant
           @renderer = renderer_engine
         end
 
+        def render
+          @renderer.render to_h
+        end
+
+        private
+
         def translator
           Alephant::Renderer::I18n::LocaleComponentYaml.new(
             translations_path,
@@ -38,12 +44,6 @@ module Alephant
         def locale
           :en
         end
-
-        def render
-          @renderer.render to_h
-        end
-
-        private
 
         def template_name
           Mustache.underscore(self.class.to_s).split("/").last

--- a/spec/integration/engine_mustache_spec.rb
+++ b/spec/integration/engine_mustache_spec.rb
@@ -8,7 +8,7 @@ describe Alephant::Renderer::Engine::Mustache do
 
   describe "Renders a template" do
     it "should render some data to a template" do
-      data = { item1 => "AAA", item2 => "bbb" }
+      data = { :item1 => "AAA", :item2 => "bbb" }
       expect(subject.render(data)).to eq("<span>AAA</span><span>bbb</span>")
     end
   end

--- a/spec/integration/engine_mustache_spec.rb
+++ b/spec/integration/engine_mustache_spec.rb
@@ -1,15 +1,18 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Alephant::Renderer::Engine::Mustache do
-  let(:base_path) { File.join(File.dirname(__FILE__), "fixtures") }
-  let(:namespace) { "sample" }
+  let(:base_path) { File.join(File.dirname(__FILE__), 'fixtures') }
+  let(:namespace) { 'sample' }
 
   subject { described_class.new(base_path, namespace) }
 
-  describe "Renders a template" do
-    it "should render some data to a template" do
-      data = { :item1 => "AAA", :item2 => "bbb" }
-      expect(subject.render(data)).to eq("<span>AAA</span><span>bbb</span>")
+  describe 'Renders a template' do
+    it 'should render some data to a template' do
+      data = {
+        item1: 'AAA',
+        item2: 'bbb'
+      }
+      expect(subject.render(data)).to eq('<span>AAA</span><span>bbb</span>')
     end
   end
 end

--- a/spec/integration/engine_mustache_spec.rb
+++ b/spec/integration/engine_mustache_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe Alephant::Renderer::Engine::Mustache do
+  let(:base_path) { File.join(File.dirname(__FILE__), "fixtures") }
+  let(:namespace) { "sample" }
+
+  subject { described_class.new(base_path, namespace) }
+
+  describe "Renders a template" do
+    it "should render some data to a template" do
+      data = { item1 => "AAA", item2 => "bbb" }
+      expect(subject.render(data)).to eq("<span>AAA</span><span>bbb</span>")
+    end
+  end
+end

--- a/spec/integration/fixtures/components/lib/templates/legacy_shared_template.mustache
+++ b/spec/integration/fixtures/components/lib/templates/legacy_shared_template.mustache
@@ -1,0 +1,1 @@
+{{module_type}} shared module template

--- a/spec/integration/fixtures/components/locale/translations.yml
+++ b/spec/integration/fixtures/components/locale/translations.yml
@@ -1,0 +1,3 @@
+en:
+  translating_module:
+    module_type: "modern"

--- a/spec/integration/fixtures/components/test-renderer/models/legacy_module.rb
+++ b/spec/integration/fixtures/components/test-renderer/models/legacy_module.rb
@@ -1,0 +1,8 @@
+module MyApp
+  class LegacyModule < Alephant::Renderer::Views::Html
+    self.template_path = '/ignored/path/to/templates'
+    def module_type
+      'legacy'
+    end
+  end
+end

--- a/spec/integration/fixtures/components/test-renderer/models/legacy_shared_module.rb
+++ b/spec/integration/fixtures/components/test-renderer/models/legacy_shared_module.rb
@@ -1,0 +1,8 @@
+module MyApp
+  class LegacySharedModule < Alephant::Renderer::Views::Html
+    self.template_path = '/ignored/path/to/shared/templates'
+    def module_type
+      'legacy'
+    end
+  end
+end

--- a/spec/integration/fixtures/components/test-renderer/models/translating_module.rb
+++ b/spec/integration/fixtures/components/test-renderer/models/translating_module.rb
@@ -1,0 +1,7 @@
+module MyApp
+  class TranslatingModule < Alephant::Renderer::Views::Html
+    def module_type
+      t 'module_type'
+    end
+  end
+end

--- a/spec/integration/fixtures/components/test-renderer/templates/legacy_module.mustache
+++ b/spec/integration/fixtures/components/test-renderer/templates/legacy_module.mustache
@@ -1,0 +1,1 @@
+{{module_type}} module template

--- a/spec/integration/fixtures/components/test-renderer/templates/legacy_shared_module.mustache
+++ b/spec/integration/fixtures/components/test-renderer/templates/legacy_shared_module.mustache
@@ -1,0 +1,1 @@
+{{>legacy_shared_template}}

--- a/spec/integration/fixtures/components/test-renderer/templates/translating_module.mustache
+++ b/spec/integration/fixtures/components/test-renderer/templates/translating_module.mustache
@@ -1,0 +1,1 @@
+{{>legacy_shared_template}}

--- a/spec/integration/fixtures/templates/sample.mustache
+++ b/spec/integration/fixtures/templates/sample.mustache
@@ -1,0 +1,1 @@
+<span>{{item1}}</span><span>{{item2}}</span>

--- a/spec/integration/fixtures/translations.yml
+++ b/spec/integration/fixtures/translations.yml
@@ -1,0 +1,9 @@
+en:
+  my_namespace:
+    some_string: "some string"
+
+cy:
+  other_namespace:
+    some_string:
+      one: "another string"
+      other: "another strings"

--- a/spec/integration/fixtures/translations.yml
+++ b/spec/integration/fixtures/translations.yml
@@ -6,4 +6,4 @@ cy:
   other_namespace:
     some_string:
       one: "another string"
-      other: "another strings"
+      other: "another %{count} strings"

--- a/spec/integration/i18n_locale_component_yaml_spec.rb
+++ b/spec/integration/i18n_locale_component_yaml_spec.rb
@@ -22,5 +22,14 @@ describe Alephant::Renderer::I18n::LocaleComponentYaml do
       }
       expect(subject.t(:some_string, params)).to eq('another string')
     end
+
+    it 'should return a pluralized translation with variable substitution' do
+      params = {
+        locale: 'cy',
+        scope:  'other_namespace',
+        count:  2
+      }
+      expect(subject.t(:some_string, params)).to eq('another 2 strings')
+    end
   end
 end

--- a/spec/integration/i18n_locale_component_yaml_spec.rb
+++ b/spec/integration/i18n_locale_component_yaml_spec.rb
@@ -1,26 +1,26 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Alephant::Renderer::I18n::LocaleComponentYaml do
-  let(:base_path) { File.join(File.dirname(__FILE__), "fixtures") }
-  let(:locale) { "en" }
-  let(:namespace) { "my_namespace" }
+  let(:template_path) { File.join(File.dirname(__FILE__), 'fixtures') }
+  let(:locale) { 'en' }
+  let(:namespace) { 'my_namespace' }
 
-  subject { described_class.new(base_path, locale, namespace) }
+  subject { described_class.new(locale, namespace, template_path) }
 
-  describe "Performs a translation" do
-    it "should return a translated string in 1 locale" do
-      expect(subject.t(:some_string)).to eq("some string")
+  describe 'Performs a translation' do
+    it 'should return a translated string in 1 locale' do
+      expect(subject.t(:some_string)).to eq('some string')
     end
   end
 
-  describe "Overridding parameters" do
-    it "should return a translation from a different locale/component" do
+  describe 'Overridding parameters' do
+    it 'should return a translation from a different locale/component' do
       params = {
-        :locale => "cy",
-        :scope  => "other_namespace",
-        :count  => 1
+        locale: 'cy',
+        scope:  'other_namespace',
+        count:  1
       }
-      expect(subject.t(:some_string, params)).to eq("another string")
+      expect(subject.t(:some_string, params)).to eq('another string')
     end
   end
 end

--- a/spec/integration/i18n_locale_component_yaml_spec.rb
+++ b/spec/integration/i18n_locale_component_yaml_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe Alephant::Renderer::I18n::LocaleComponentYaml do
+  let(:base_path) { File.join(File.dirname(__FILE__), "fixtures") }
+  let(:locale) { "en" }
+  let(:namespace) { "my_namespace" }
+
+  subject { described_class.new(base_path, locale, namespace) }
+
+  describe "Performs a translation" do
+    it "should return a translated string in 1 locale" do
+      expect(subject.t(:some_string)).to eq("some string")
+    end
+  end
+
+  describe "Overridding parameters" do
+    it "should return a translation from a different locale/component" do
+      params = {
+        :locale => "cy",
+        :scope  => "other_namespace",
+        :count  => 1
+      }
+      expect(subject.t(:some_string, params)).to eq("another string")
+    end
+  end
+end

--- a/spec/integration/views_html_spec.rb
+++ b/spec/integration/views_html_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require_relative 'fixtures/components/test-renderer/models/legacy_module'
+require_relative 'fixtures/components/test-renderer/models/legacy_shared_module'
+require_relative 'fixtures/components/test-renderer/models/translating_module'
+
+describe Alephant::Renderer::Views::Html do
+  let(:data) { nil }
+  let(:test_renderer) { MyApp::LegacyModule }
+
+  subject { test_renderer.new(data) }
+
+  describe 'Interface tests (backwards compatibility)' do
+    it 'should accept self.template_path calls' do
+      expect(subject.class.template_path).to eq('/ignored/path/to/templates')
+    end
+
+    it 'should render from a local template (with template_path set)' do
+      expect(subject.render).to eq('legacy module template')
+    end
+
+    describe 'Shared template test' do
+      let(:test_renderer) { MyApp::LegacySharedModule }
+
+      it 'should render a local template that points to a shared template (with template_path set)' do
+        expect(subject.render).to eq('legacy shared module template')
+      end
+    end
+  end
+
+  describe 'Interface tests' do
+    describe 'Translation test' do
+      before(:all) do
+        ::I18n.backend = I18n::Backend::Simple.new
+      end
+
+      let(:test_renderer) { MyApp::TranslatingModule }
+
+      it 'should render a template with a translated string' do
+        expect(subject.render).to eq('modern shared module template')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$: << File.join(File.dirname(__FILE__),"..", "lib")
+$LOAD_PATH << File.join(File.dirname(__FILE__),"..", "lib")
 
 require "pry"
 require "json"

--- a/trans.yml
+++ b/trans.yml
@@ -1,2 +1,0 @@
-en:
-  test: 'Hello!'


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/CONNPOL-3647

![liquid_separation](https://cloud.githubusercontent.com/assets/3382882/16661392/a1de2ad2-446a-11e6-8541-094d26981a06.gif)

This is to separate the translations and renderer engines out of the render model hierarchy in order to:
- Allow alternative implementations of the translations
- Allow translations to work in the JSON renderer
- Allow us to render snippets of HTML from the JSON renderer
- Separate concerns

Note that this obseletes setting `self.template_path`. If a renderer sets `self.template_path` to anything other than the shared template path, i.e. `src/components/lib/templates`, then it needs to set its' path now using this snippet:
```ruby
def renderer_engine
  partial_path = File.join(base_path, "templates/")
  Alephant::Renderer::Engine::Mustache.new(base_path, template_name, partial_path)
end
```
In the above example, it sets it to the path of the current renderer's templates path.