### PR TITLE
Add class to parse translation files formatted in JSON

### DIFF
--- a/lib/alephant/renderer/i18n/json.rb
+++ b/lib/alephant/renderer/i18n/json.rb
@@ -21,9 +21,7 @@ module Alephant
         end
 
         def translation_filename
-          File.join(
-            translations_path,
-            '*.json')
+          File.join(translations_path, '*.json')
         end
       end
     end

--- a/lib/alephant/renderer/i18n/json.rb
+++ b/lib/alephant/renderer/i18n/json.rb
@@ -1,0 +1,31 @@
+require 'json'
+
+module Alephant
+  module Renderer
+    module I18n
+      class Json < LocaleComponentYaml
+        private
+
+        def load_translations
+          return unless i18n_lib.load_path.empty?
+          translations_files.map do |file|
+            store_translation(file)
+          end
+        end
+
+        def store_translation(file)
+          translations = JSON.parse(File.read(file))
+          translations.each do |locale, content|
+            i18n_lib.backend.store_translations(locale, content)
+          end
+        end
+
+        def translation_filename
+          File.join(
+            translations_path,
+            '*.json')
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/fixtures/translations.json
+++ b/spec/integration/fixtures/translations.json
@@ -1,0 +1,15 @@
+{
+    "en": {
+        "my_namespace": {
+            "some_string": "some string"
+        }
+    },
+    "cy": {
+        "other_namespace": {
+            "some_string": {
+                "one": "another string",
+                "other": "another %{count} strings"
+            }
+        }
+    }
+}

--- a/spec/integration/i18n_json_spec.rb
+++ b/spec/integration/i18n_json_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require File.dirname(__FILE__) + '/../../lib/alephant/renderer/i18n/json'
+
+describe Alephant::Renderer::I18n::Json do
+  let(:template_path) { File.join(File.dirname(__FILE__), 'fixtures') }
+  let(:locale) { 'en' }
+  let(:namespace) { 'my_namespace' }
+
+  subject { described_class.new(locale, namespace, template_path) }
+
+  describe 'json translations' do
+    let(:params) do
+      {
+        locale: 'cy',
+        count:  1,
+        scope:  'other_namespace'
+      }
+    end
+    it 'should translate a string held in a json document' do
+      expect(subject.t(:some_string, params)).to eq('another string')
+    end
+  end
+end


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/CONNPOL-3644

![little_german](https://cloud.githubusercontent.com/assets/3382882/17098996/69bd3dc2-525d-11e6-9cbf-3f6b6b0c27ea.gif)

This makes a new translation class available that can read the translations from JSON files instead of YAML files. As it's expected that currently all alephant projects are using YAML files, so JSON translations have to be explicitly added to renderers, e.g.
```ruby
require 'alephant/renderer/i18n/json'
module DataRenderer
  module Views
    class MyRenderer < Alephant::Renderer::Views::Html
      def translator
        Alephant::Renderer::I18n::Json.new(
          locale,
          template_name,
          translations_path)
      end
    end
  end
end
```
Once this method is in place, the renderer can use `t()` as normal.